### PR TITLE
chore(deps): Add pull_request_target to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, edited, closed, reopened]
   pull_request:
     types: [opened, edited, closed, reopened, synchronize]
+  pull_request_target:
+    types: [opened, edited, closed, reopened, synchronize]
   project_card:
     types: [created, moved, deleted]
   schedule: [cron: "0 * * * *"]
@@ -14,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: ./packages/release-mastermind/
+      - name: Release Mastermind
+        uses: Videndum/release-mastermind@latest
         with:
           GITHUB_TOKEN: "${{ secrets.BOT_TOKEN }}"
           config: .github/allconfigs.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Release Mastermind
-        uses: Videndum/release-mastermind@latest
+        uses: Videndum/release-mastermind@0.0.0-alpha.7
         with:
           GITHUB_TOKEN: "${{ secrets.BOT_TOKEN }}"
           config: .github/allconfigs.json


### PR DESCRIPTION
his is as a result of a change to how pull requests from Dependabot are being treated as described below:

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories-1

Consequently, this means that any job that references secrets will fail if that pull request was triggered by Dependabot. Rerunning the workflow solves the issue because it changes the actor to the user rerunning the workflow, who must have write access to the repository and therefore secrets are made available on that run.

The change is a security update made to prevent potentially compromised dependencies from capturing secrets referenced in your workflows.

The article below provides details of how to use the workflow_run in combination with the pull_request event to handle such scenarios as the one that arises from Dependabot opening a pull request:

https://securitylab.github.com/research/github-actions-preventing-pwn-request